### PR TITLE
Squash (#13)

### DIFF
--- a/modules/javafx.graphics/src/main/jsl-prism/PrismLoaderGlue.stg
+++ b/modules/javafx.graphics/src/main/jsl-prism/PrismLoaderGlue.stg
@@ -7,7 +7,9 @@ glue(shaderName,samplerInit,paramInit,maxTexCoordIndex,isPixcoordUsed) ::= <<
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -19,9 +21,9 @@ glue(shaderName,samplerInit,paramInit,maxTexCoordIndex,isPixcoordUsed) ::= <<
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
- * CA 95054 USA or visit www.sun.com if you need additional information or
- * have any questions.
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 /*

--- a/modules/javafx.media/src/main/native/jfxmedia/platform/osx/OSXPlatform.mm
+++ b/modules/javafx.media/src/main/native/jfxmedia/platform/osx/OSXPlatform.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,26 @@
 JNIEXPORT jboolean JNICALL Java_com_sun_media_jfxmediaimpl_platform_osx_OSXPlatform_osxPlatformInit
     (JNIEnv *env, jclass klass)
 {
+    // Workaround for JDK-8202393. All errors will be considered as warnings if code below fails.
+    NSBundle *main = [NSBundle mainBundle];
+    if (main != nil) {
+        NSDictionary *dictionary = main.infoDictionary;
+        if (dictionary != nil) {
+            if ([dictionary isKindOfClass:[NSMutableDictionary class]]) {
+                NSMutableDictionary *mDictionary = (NSMutableDictionary *)dictionary;
+                NSDictionary *data = @{@"NSAllowsArbitraryLoads" : @YES, @"NSAllowsArbitraryLoadsForMedia" : @YES};
+                mDictionary[@"NSAppTransportSecurity"] = data;
+                LOGGER_INFOMSG("OSXPlatform: Info dictionary updated successfully.");
+            } else {
+                LOGGER_WARNMSG("OSXPlatform: Info dictionary is not mutable dictionary.");
+            }
+        } else {
+            LOGGER_WARNMSG("OSXPlatform: Cannot get info dictionary.");
+        }
+    } else {
+        LOGGER_WARNMSG("OSXPlatform: Cannot get main bundle.");
+    }
+
     // Tell OSXMediaPlayer to initialize itself
     return (jboolean)[OSXMediaPlayer initPlayerPlatform];
 }

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCFontImpl.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCFontImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -261,6 +261,9 @@ final class WCFontImpl extends WCFont {
     @Override public float[] getGlyphBoundingBox(int glyph) {
         float[] bb = new float[4];
         bb = getFontStrike().getFontResource().getGlyphBoundingBox(glyph, font.getSize(), bb);
+        // Depends on the defaults fonts.
+        // Best choice for a custom Latin Modern Math Font.
+        // bb[1]= -getAscent();
         bb[1]= -getCapHeight();
         bb[3]= getDescent()-bb[1];
         return bb;

--- a/modules/javafx.web/src/main/java/com/sun/webkit/graphics/WCFont.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/graphics/WCFont.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/java/com/sun/webkit/perf/WCFontPerfLogger.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/perf/WCFontPerfLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/FontJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/FontJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tests/system/src/test/java/test/javafx/scene/web/OpenJFXMathMLRenderingIssueTest
+++ b/tests/system/src/test/java/test/javafx/scene/web/OpenJFXMathMLRenderingIssueTest
@@ -34,8 +34,8 @@ import javafx.stage.Stage;
 
 /**
  * @test
- * @bug JDK-8147476 Rendering issues with MathML token elements
- * @bug JDK-8089878 HTMLEditor messes up MathML markup press
+ * @bug JDK-8147476 Rendering issues with MathML token elements.
+ * @bug JDK-8089878 HTMLEditor messes up MathML markup press.
  */
 public class OpenJFXMathMLRenderingIssueTest extends Application {
 


### PR DESCRIPTION
* 8202393: App Transport Security blocks http media on macOS with JDK build using new compilers
Reviewed-by: kcr

* 8203801: Missing Classpath exception in PrismLoaderGlue.stg file
Reviewed-by: prr

* Update the master branch. (#10)

* Set the locale of the javadoc

Setting the locale to a fixed value when generating the javadoc ensures the output of the build doesn't depend on developer specific settings. This improves the reproducibility of the build.

* Fix PosixPlatform.cpp compilation with GCC 6

* Create CONTRIBUTING.md

* Fix launcher library compilation with GCC 6

* fix NPE in getMediaName()

* 8199841: Add gradle wrapper files to build
Reviewed-by: jvos
Contributed-by: aalmiray@gmail.com

* Add Gradle wrapper files

* Update ci scripts to use gradlew

* Gradle build failure should show informative message

* 8195799: Use System logger instead of platform logger in javafx modules
Reviewed-by: kcr, mchung, dfuchs, jvos

* Added tag jdk-11+7 for changeset 0cd88e183e61

* 8088769: Alphachannel for transparent colors is not shown in HtmlEditor
Reviewed-by: kcr, mbilla

* 8200277: Compiling native media code fails when using OpenJDK build as boot JDK

* Qt-dev tools are no longer needed by OpenJFX (#48)

* Additional updates needed for JDK-8199841 to add gradle wrapper files to build (#49)

1. Added the gradle.md license file
2. Replaced gradle-wrapper.jar with one generated from gradle 4.3 to match the version in the license file (we shouldn't need to update this again after this)
With the above changes, there should be no merge conflicts when JDK-8199841 is integrated to the upstream openjfx/jfx-dev repo.

* 8200277: Compiling native media code fails when using OpenJDK build as boot JDK
Reviewed-by: jvos, prr

* Added tag jdk-11+8 for changeset b956f9ea2553

* add script used by jenkins job to sync with openjfx mercurial repository

* 8193311: [Spinner] Default button not activated on ENTER
Reviewed-by: kcr, aghaisas

* Use JDK 10 on Travis CI and Appveyor. (#63)

* Created a basic .gitignore file (#60)

* Update ci scripts to use gradlew

* Qt-dev tools are no longer needed by OpenJFX (#48)

* Use JDK 10 on Travis CI and Appveyor. (#63)

* Created a basic .gitignore file (#60)

* 8200749: Update javadoc build to enable tags used by JDK and fix broken URL
Reviewed-by: kcr

* 8130379: Enhance the Bounds class with getCenter method
Reviewed-by: kcr

* Added tag jdk-11+9 for changeset 4184d3dccefa

* 8200629: Update SQLite to version 3.23.0
Reviewed-by: kcr, mbilla

* 8192056: Memory leak when removing javafx.scene.shape.Sphere-objects from a group or container
Reviewed-by: kcr, nlisker

* 8185854: NPE on non-editable ComboBox in TabPane with custom Skin
Reviewed-by: kcr, arapte

* 8200587: Fix mistakes in FX API docs
Reviewed-by: kcr

* 8201176: gradle :web:test should print a warning if COMPILE_WEBKIT is false
Reviewed-by: kcr

* 8199357: Remove references to applets and Java Web Start from FX
Reviewed-by: prr, aghaisas

* 8200300: better gradle error message
Reviewed-by: kcr, arapte
Contributed-by: abhinay.agarwal@gluonhq.com

* Added tag jdk-11+10 for changeset b9915cc91652

* 8157690: [TabPane] Sorting tabs makes tab selection menu empty
Reviewed-by: kcr, aghaisas

* JDK-8195669 Cross Compile Arm Swing no longer fails (#58)

* add script used by jenkins job to sync with openjfx mercurial repository

* Fixes #54: Cross compile armv6hf build no longer fails with swing errors

* add timeout to antlr processing, fixing https://github.com/javafxports/openjdk-jfx/issues/25 (#68)

* 8199765: antlr timeout
Reviewed-by: kcr
Contributed-by: ebourg@apache.org

* 8177380: Add standard colors in ColorPicker color palette
Reviewed-by: nlisker, kcr

* 8202036: Update OpenJFX license files to match OpenJDK
Reviewed-by: prr

* 8195669: cross compiler on ARM fails
Reviewed-by: kcr
Contributed-by: mario@datenwort.at, dell.green@ideaworks.co.uk

* 8167096: Add APIs to customize step repeat timing for Spinner control
Reviewed-by: kcr, aghaisas

* Added tag jdk-11+11 for changeset 299108465d55

* 8198329: Support FX build / test using JDK that doesn't include javafx.* modules
Reviewed-by: prr, jvos, aghaisas

* Added tag jdk-11+12 for changeset f29f3fbe6810

* Generate PDB (debugging files) and upload them via Appveyor. (#67)

targeting master branch

* (travis) Set CONF gradle property to 'DebugNative'. (#74)

* 8200418: webPage.executeCommand("removeFormat", null) removes the style of the body element
Reviewed-by: kcr, rkamath

* 8197987: Update libxslt to version 1.1.32
Reviewed-by: kcr, mbilla

* Added tag jdk-11+13 for changeset 1cf615e434d5

* 8196827: test.javafx.scene.control.ComboBoxTest - generates NullPointerException
Reviewed-by: kcr, arapte

* 8198602: [TestBug] test.javafx.css.StylesheetTest logs IllegalArgumentException
Reviewed-by: kcr, aghaisas

* 8196844: [TestBug] IllegalArgumentException gets logged in some of test.javafx.scene.* tests
Reviewed-by: kcr, aghaisas

* 8202368: Create jmods for standalone javafx modules
Reviewed-by: aghaisas, prr

* 8198601: [TestBug] test.robot.javafx.scene.layout.RegionBackgroundFillUITest logs IllegalArgumentException
Reviewed-by: kcr, aghaisas

* 8199344: [testbug] Illegal reflective access by NGTestBase
Reviewed-by: kcr, aghaisas

* 8201261: Ability to override the dependency repositories used by gradle
Reviewed-by: prr

* 8163795: [Windows] Remove call to StretchBlt in native GetScreenCapture method
Reviewed-by: kcr

* Added tag jdk-11+14 for changeset afd9c2c1828d

* 8193590: Memory leak when using WebView with Tooltip
Reviewed-by: kcr, arajkumar

* 8202623: [TEST_BUG] Some launcher tests will hang if underlying process exits too early
Reviewed-by: kcr, aghaisas

* 8203365: [TESTBUG] Mark MeshManagerCacheLeakTest as unstable until test is fixed
Reviewed-by: kcr

* 8203378: JDK build fails to compile javafx.graphics module-info.java if FX was built with OpenJDK
Reviewed-by: prr

* Unify master and develop branch (#80)

* Use correct status badge for appveyor (#82)

* JDK-8202396: Fix memory leak in ImageLoader.m (#73)

* 8199614: [macos] ImageCursor.getBestSize() throws NullPointerException
Reviewed-by: mbilla, arapte, kcr

* 8203294: [Linux] Link libgcc and libstdc++ statically to support gcc-7.x
Reviewed-by: kcr, mbilla

* 8201285: DateCell text color are not updated correctly when DateCell with disable = true is reused
Reviewed-by: aghaisas, kcr

* 8202396: memory leak ios imageloader
Reviewed-by: kcr
Contributed-by: jose.pereda@gluonhq.com

* 8203698: JavaFX WebView crashes when visiting certain web sites
Reviewed-by: kcr, arajkumar
Contributed-by: murali.billa@oracle.com, arunprasad.rajkumar@oracle.com

* Fix JDK-8202743: Dashed Stroke randomly painted incorrectly, may freeze application (#87)

8202743: Dashed Stroke randomly painted incorrectly, may freeze application
Reviewed-by: kcr

* 8129582: Controls slow considerably when displaying RTL-languages text on Linux
Reviewed-by: kcr

* 8202743: Dashed BasicStroke randomly painted incorrectly, may freeze application
Summary: fixed Dasher.init() to use the correct part [0; dashLen[
Reviewed-by: kcr

* [#85, #86] Use OpenJDK for CI, use "gradle all test" instead of "gradle build". (#88)

* Use OpenJDK instead of Oracle JDK for CI.

Fixes #86

* Run "gradle all test" instead of "gradle build" for CI.

Fixes #85

* 8195808: Eliminate dependency on sun.print in javafx.graphics
Reviewed-by: kcr

* Update WCFontImpl.java

// Guy Abossolo Foh : Implémentation pour corriger le Bug de MathML.

* Update FontJava.cpp

* Fix JDK-8201553: Update FX build to use gradle 4.8 (#92)

Reviewed-by: @prrace @johanvos @tiainen

* Merge changes from github/master before pushing (#91)

Pull changes from github master into local master before pushing to github

* 8201553: Update FX build to use gradle 4.8
Reviewed-by: prr, jvos

* Create gradle.properties

* Delete gradle.properties

* Create gradle.properties

* Update gradle.properties

Enable WebKit build.

* Update gradle.properties

* Update FontJava.cpp

* Update FontJava.cpp

Small change : wrong object return if not jFont.

* Update FontJava.cpp

* Update WCFontImpl.java

* Update WCFont.java

* Update FontJava.cpp

* Update WCFontPerfLogger.java

* Update WCFontImpl.java

* Create OpenJFXMathMLRenderingIssueTest

Test for :
- JDK-8147476 Rendering issues with MathML token elements
- JDK-8089878 HTMLEditor messes up MathML markup press

* Move file.

Kevin : If you need to display a window, it will need to go into tests/system instead of modules/javafx.web.

* Delete gradle.properties

Kevin : You need to remove the gradle.properties file. It should not be checked in.

* Update OpenJFXMathMLRenderingIssueTest

* Update WCFontImpl.java

* Update WCFont.java

* Update WCFontImpl.java

* Update FontJava.cpp

* Update WCFontPerfLogger.java